### PR TITLE
#2 implement CSV Data Source core parser pipeline 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 .venv/
+.venv*/
 venv/
 __pycache__/
 *.pyc
+.idea/
+**/build/
+**/*.egg-info/
+.vscode/

--- a/data_source_csv/README.md
+++ b/data_source_csv/README.md
@@ -1,0 +1,70 @@
+# CSV Data Source Plugin
+
+`data_source_csv` is a pluggable data-source package that implements the shared
+`DataSourcePlugin` contract from `graph-api`.
+
+It uses:
+- Template Method for the parsing pipeline (`load -> read -> parse -> build -> validate`)
+- Strategy for CSV representation variants
+
+Currently implemented strategy:
+- `edge_list`
+
+Extension points (planned in follow-up issues):
+- `adjacency_list`
+- `matrix`
+
+## Install
+
+From repository root:
+
+```bash
+pip install -e ./api
+pip install -e ./data_source_csv
+```
+
+## Plugin Parameters
+
+- `file_path` (required): path to CSV file.
+- `format` (required): one of `edge_list`, `adjacency_list`, `matrix`.
+- `delimiter` (optional): single-character delimiter, default `,`.
+- `graph_id` (optional): graph id; defaults to CSV filename stem.
+
+## Edge List CSV Format
+
+Required columns:
+- `source`
+- `target`
+
+Optional columns:
+- `edge_id` (auto-generated when missing)
+- `directed` (`true/false`, `yes/no`, `1/0`)
+- `source_<attr_name>` for source-node attributes
+- `target_<attr_name>` for target-node attributes
+- `edge_<attr_name>` for edge attributes
+
+Type inference is applied to attribute values:
+- `int`, `float`, `date` (`YYYY-MM-DD`, `YYYY/MM/DD`, `DD.MM.YYYY`), otherwise `str`.
+
+Example:
+
+```csv
+source,target,edge_id,directed,source_age,target_age,edge_weight,source_joined
+n1,n2,e1,true,21,22,0.5,2024-01-10
+n2,n3,e2,false,22,23,1.25,2024-02-11
+```
+
+## Usage Example
+
+```python
+from csv_data_source import CsvDataSourcePlugin
+
+plugin = CsvDataSourcePlugin()
+graph = plugin.load_graph(
+    {
+        "file_path": "/path/to/graph.csv",
+        "format": "edge_list",
+        "delimiter": ",",
+    }
+)
+```

--- a/data_source_csv/csv_data_source/__init__.py
+++ b/data_source_csv/csv_data_source/__init__.py
@@ -1,0 +1,12 @@
+from .errors import CsvParameterError, CsvParsingError, CsvPluginError
+from .pipeline import CsvParsingPipeline, DefaultCsvParsingPipeline
+from .plugin import CsvDataSourcePlugin
+
+__all__ = [
+    "CsvDataSourcePlugin",
+    "CsvParsingPipeline",
+    "DefaultCsvParsingPipeline",
+    "CsvPluginError",
+    "CsvParameterError",
+    "CsvParsingError",
+]

--- a/data_source_csv/csv_data_source/errors.py
+++ b/data_source_csv/csv_data_source/errors.py
@@ -1,0 +1,10 @@
+class CsvPluginError(ValueError):
+    """Base error for CSV data-source plugin failures."""
+
+
+class CsvParameterError(CsvPluginError):
+    """Raised for invalid or missing plugin parameters."""
+
+
+class CsvParsingError(CsvPluginError):
+    """Raised for CSV content/format parsing problems."""

--- a/data_source_csv/csv_data_source/models.py
+++ b/data_source_csv/csv_data_source/models.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from graph_api.model.attribute import AttributeValue
+
+
+@dataclass(slots=True, frozen=True)
+class CsvLoadConfig:
+    file_path: Path
+    format_name: str
+    delimiter: str
+    graph_id: str
+
+
+@dataclass(slots=True, frozen=True)
+class CsvRows:
+    fieldnames: tuple[str, ...]
+    rows: list[dict[str, str]]
+
+
+@dataclass(slots=True, frozen=True)
+class ParsedEdge:
+    edge_id: str
+    source_id: str
+    target_id: str
+    directed: bool
+    attributes: dict[str, AttributeValue]
+
+
+@dataclass(slots=True)
+class ParsedGraphData:
+    node_attributes: dict[str, dict[str, AttributeValue]] = field(default_factory=dict)
+    edges: list[ParsedEdge] = field(default_factory=list)

--- a/data_source_csv/csv_data_source/pipeline.py
+++ b/data_source_csv/csv_data_source/pipeline.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import csv
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from graph_api.model.edge import Edge
+from graph_api.model.graph import Graph
+from graph_api.model.node import Node
+
+from .errors import CsvParameterError, CsvParsingError
+from .models import CsvLoadConfig, CsvRows, ParsedGraphData
+from .strategies import (
+    AdjacencyListCsvStrategy,
+    CsvFormatStrategy,
+    EdgeListCsvStrategy,
+    MatrixCsvStrategy,
+)
+
+
+class CsvParsingPipeline(ABC):
+    """Template Method pipeline for converting CSV input into Graph."""
+
+    def execute(self, parameter_values: dict[str, str]) -> Graph:
+        config = self.load(parameter_values)
+        csv_rows = self.read(config)
+        parsed_graph = self.parse(csv_rows, config)
+        graph = self.build(parsed_graph, config)
+        self.validate(graph, config)
+        return graph
+
+    @abstractmethod
+    def load(self, parameter_values: dict[str, str]) -> CsvLoadConfig:
+        raise NotImplementedError
+
+    @abstractmethod
+    def read(self, config: CsvLoadConfig) -> CsvRows:
+        raise NotImplementedError
+
+    @abstractmethod
+    def parse(self, csv_rows: CsvRows, config: CsvLoadConfig) -> ParsedGraphData:
+        raise NotImplementedError
+
+    @abstractmethod
+    def build(self, parsed_graph: ParsedGraphData, config: CsvLoadConfig) -> Graph:
+        raise NotImplementedError
+
+    @abstractmethod
+    def validate(self, graph: Graph, config: CsvLoadConfig) -> None:
+        raise NotImplementedError
+
+
+class DefaultCsvParsingPipeline(CsvParsingPipeline):
+    def __init__(self, strategies: list[CsvFormatStrategy] | None = None) -> None:
+        resolved_strategies = strategies or [
+            EdgeListCsvStrategy(),
+            AdjacencyListCsvStrategy(),
+            MatrixCsvStrategy(),
+        ]
+        self._strategies: dict[str, CsvFormatStrategy] = {
+            strategy.format_name: strategy for strategy in resolved_strategies
+        }
+
+    def load(self, parameter_values: dict[str, str]) -> CsvLoadConfig:
+        file_path_raw = parameter_values.get("file_path", "").strip()
+        if file_path_raw == "":
+            raise CsvParameterError("Missing required parameter 'file_path'.")
+
+        format_name = parameter_values.get("format", "").strip().lower()
+        if format_name == "":
+            raise CsvParameterError("Missing required parameter 'format'.")
+        if format_name not in self._strategies:
+            supported = ", ".join(sorted(self._strategies.keys()))
+            raise CsvParameterError(
+                f"Unsupported CSV format '{format_name}'. Supported formats: {supported}."
+            )
+
+        delimiter = parameter_values.get("delimiter", ",").strip() or ","
+        if len(delimiter) != 1:
+            raise CsvParameterError("Parameter 'delimiter' must be a single character.")
+
+        file_path = Path(file_path_raw).expanduser()
+        if not file_path.exists():
+            raise CsvParameterError(f"CSV file '{file_path}' does not exist.")
+        if not file_path.is_file():
+            raise CsvParameterError(f"CSV path '{file_path}' is not a file.")
+
+        graph_id = parameter_values.get("graph_id", "").strip() or file_path.stem
+
+        return CsvLoadConfig(
+            file_path=file_path,
+            format_name=format_name,
+            delimiter=delimiter,
+            graph_id=graph_id,
+        )
+
+    def read(self, config: CsvLoadConfig) -> CsvRows:
+        with config.file_path.open("r", encoding="utf-8-sig", newline="") as csv_file:
+            reader = csv.DictReader(csv_file, delimiter=config.delimiter)
+            if not reader.fieldnames:
+                raise CsvParsingError("CSV file must contain a header row.")
+
+            fieldnames = tuple(name.strip() for name in reader.fieldnames if name and name.strip())
+            if not fieldnames:
+                raise CsvParsingError("CSV header row is empty.")
+
+            rows: list[dict[str, str]] = []
+            for row in reader:
+                normalized_row: dict[str, str] = {}
+                for key, value in row.items():
+                    if key is None:
+                        continue
+                    normalized_row[key.strip()] = "" if value is None else value.strip()
+                if any(cell != "" for cell in normalized_row.values()):
+                    rows.append(normalized_row)
+
+        if not rows:
+            raise CsvParsingError("CSV file does not contain any non-empty data rows.")
+
+        return CsvRows(fieldnames=fieldnames, rows=rows)
+
+    def parse(self, csv_rows: CsvRows, config: CsvLoadConfig) -> ParsedGraphData:
+        strategy = self._strategies[config.format_name]
+        return strategy.parse_rows(csv_rows)
+
+    def build(self, parsed_graph: ParsedGraphData, config: CsvLoadConfig) -> Graph:
+        graph = Graph(
+            graph_id=config.graph_id,
+            directed_default=True,
+            allow_cycles=True,
+        )
+
+        for node_id, attributes in parsed_graph.node_attributes.items():
+            node = Node(node_id=node_id)
+            for attr_name, attr_value in attributes.items():
+                node.set_attribute(attr_name, attr_value)
+            graph.add_node(node)
+
+        for edge_data in parsed_graph.edges:
+            edge = Edge(
+                edge_id=edge_data.edge_id,
+                source_id=edge_data.source_id,
+                target_id=edge_data.target_id,
+                directed=edge_data.directed,
+            )
+            for attr_name, attr_value in edge_data.attributes.items():
+                edge.set_attribute(attr_name, attr_value)
+            graph.add_edge(edge)
+
+        return graph
+
+    def validate(self, graph: Graph, config: CsvLoadConfig) -> None:
+        if len(graph.nodes) == 0:
+            raise CsvParsingError("Parsed graph contains no nodes.")
+        if len(graph.edges) == 0:
+            raise CsvParsingError("Parsed graph contains no edges.")

--- a/data_source_csv/csv_data_source/plugin.py
+++ b/data_source_csv/csv_data_source/plugin.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from graph_api.contracts.data_source import DataSourcePlugin, PluginParameter
+from graph_api.model.graph import Graph
+
+from .errors import CsvParameterError
+from .pipeline import CsvParsingPipeline, DefaultCsvParsingPipeline
+
+
+class CsvDataSourcePlugin(DataSourcePlugin):
+    def __init__(self, pipeline: CsvParsingPipeline | None = None) -> None:
+        self._pipeline = pipeline or DefaultCsvParsingPipeline()
+
+    @property
+    def plugin_id(self) -> str:
+        return "csv_data_source"
+
+    @property
+    def display_name(self) -> str:
+        return "CSV Data Source"
+
+    @property
+    def parameters(self) -> list[PluginParameter]:
+        return [
+            PluginParameter(
+                name="file_path",
+                description="Path to the CSV file that should be loaded.",
+                required=True,
+            ),
+            PluginParameter(
+                name="format",
+                description="CSV graph format: edge_list, adjacency_list, matrix.",
+                required=True,
+            ),
+            PluginParameter(
+                name="delimiter",
+                description="Optional CSV delimiter (single character, default ',').",
+                required=False,
+            ),
+            PluginParameter(
+                name="graph_id",
+                description="Optional graph identifier (defaults to CSV filename).",
+                required=False,
+            ),
+        ]
+
+    def load_graph(self, parameter_values: dict[str, str]) -> Graph:
+        if not isinstance(parameter_values, dict):
+            raise CsvParameterError("Parameter values must be provided as a dictionary.")
+        return self._pipeline.execute(parameter_values)

--- a/data_source_csv/csv_data_source/strategies.py
+++ b/data_source_csv/csv_data_source/strategies.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from graph_api.model.attribute import AttributeValue
+
+from .errors import CsvParsingError
+from .models import CsvRows, ParsedEdge, ParsedGraphData
+from .type_inference import infer_attribute_value
+
+
+class CsvFormatStrategy(ABC):
+    @property
+    @abstractmethod
+    def format_name(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def parse_rows(self, csv_rows: CsvRows) -> ParsedGraphData:
+        raise NotImplementedError
+
+
+class EdgeListCsvStrategy(CsvFormatStrategy):
+    _REQUIRED_COLUMNS = ("source", "target")
+    _TRUTHY = {"1", "true", "yes", "y", "t"}
+    _FALSY = {"0", "false", "no", "n", "f"}
+
+    @property
+    def format_name(self) -> str:
+        return "edge_list"
+
+    def parse_rows(self, csv_rows: CsvRows) -> ParsedGraphData:
+        missing_columns = [
+            column for column in self._REQUIRED_COLUMNS if column not in csv_rows.fieldnames
+        ]
+        if missing_columns:
+            raise CsvParsingError(
+                "Edge list CSV is missing required columns: " + ", ".join(missing_columns)
+            )
+
+        parsed = ParsedGraphData()
+        seen_edge_ids: set[str] = set()
+        auto_edge_id = 1
+
+        for row_index, row in enumerate(csv_rows.rows, start=2):
+            source_id = self._get_required_cell(row, "source", row_index)
+            target_id = self._get_required_cell(row, "target", row_index)
+
+            parsed.node_attributes.setdefault(source_id, {})
+            parsed.node_attributes.setdefault(target_id, {})
+
+            parsed.node_attributes[source_id].update(self._extract_prefixed(row, "source_"))
+            parsed.node_attributes[target_id].update(self._extract_prefixed(row, "target_"))
+
+            edge_id = row.get("edge_id", "").strip()
+            if edge_id == "":
+                edge_id = f"e{auto_edge_id}"
+                auto_edge_id += 1
+
+            if edge_id in seen_edge_ids:
+                raise CsvParsingError(f"Duplicate edge_id '{edge_id}' at row {row_index}.")
+            seen_edge_ids.add(edge_id)
+
+            directed_raw = row.get("directed", "").strip()
+            directed = True if directed_raw == "" else self._parse_bool(directed_raw, row_index)
+
+            parsed.edges.append(
+                ParsedEdge(
+                    edge_id=edge_id,
+                    source_id=source_id,
+                    target_id=target_id,
+                    directed=directed,
+                    attributes=self._extract_prefixed(row, "edge_"),
+                )
+            )
+
+        return parsed
+
+    def _get_required_cell(self, row: dict[str, str], key: str, row_index: int) -> str:
+        value = row.get(key, "").strip()
+        if value == "":
+            raise CsvParsingError(f"Row {row_index} has empty required '{key}' value.")
+        return value
+
+    def _extract_prefixed(self, row: dict[str, str], prefix: str) -> dict[str, AttributeValue]:
+        attributes: dict[str, AttributeValue] = {}
+        for key, value in row.items():
+            if not key.startswith(prefix):
+                continue
+            attr_name = key[len(prefix) :].strip()
+            if attr_name == "":
+                continue
+            if value.strip() == "":
+                continue
+            attributes[attr_name] = infer_attribute_value(value)
+        return attributes
+
+    def _parse_bool(self, value: str, row_index: int) -> bool:
+        lowered = value.strip().lower()
+        if lowered in self._TRUTHY:
+            return True
+        if lowered in self._FALSY:
+            return False
+        raise CsvParsingError(
+            f"Row {row_index} contains invalid directed flag '{value}'. "
+            "Use true/false, yes/no, 1/0."
+        )
+
+
+class AdjacencyListCsvStrategy(CsvFormatStrategy):
+    @property
+    def format_name(self) -> str:
+        return "adjacency_list"
+
+    def parse_rows(self, csv_rows: CsvRows) -> ParsedGraphData:
+        raise CsvParsingError("CSV format 'adjacency_list' is not implemented yet.")
+
+
+class MatrixCsvStrategy(CsvFormatStrategy):
+    @property
+    def format_name(self) -> str:
+        return "matrix"
+
+    def parse_rows(self, csv_rows: CsvRows) -> ParsedGraphData:
+        raise CsvParsingError("CSV format 'matrix' is not implemented yet.")

--- a/data_source_csv/csv_data_source/type_inference.py
+++ b/data_source_csv/csv_data_source/type_inference.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from graph_api.model.attribute import AttributeValue
+
+_INT_PATTERN = re.compile(r"[+-]?\d+")
+_FLOAT_PATTERN = re.compile(r"[+-]?(?:\d+\.\d*|\d*\.\d+)")
+_DATE_FORMATS = ("%Y-%m-%d", "%Y/%m/%d", "%d.%m.%Y")
+
+
+def infer_attribute_value(raw: str) -> AttributeValue:
+    value = raw.strip()
+    if value == "":
+        return ""
+
+    if _INT_PATTERN.fullmatch(value):
+        return int(value)
+
+    if _FLOAT_PATTERN.fullmatch(value):
+        return float(value)
+
+    for date_format in _DATE_FORMATS:
+        try:
+            return datetime.strptime(value, date_format).date()
+        except ValueError:
+            continue
+
+    return value

--- a/data_source_csv/pyproject.toml
+++ b/data_source_csv/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "data-source-csv"
+version = "0.1.0"
+description = "CSV data source plugin for graph visualization platform"
+requires-python = ">=3.11"
+dependencies = [
+    "graph-api"
+]
+
+[project.entry-points."graph_platform.data_source_plugins"]
+csv = "csv_data_source.plugin:CsvDataSourcePlugin"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/data_source_csv/tests/fixtures/edge_list_invalid_directed.csv
+++ b/data_source_csv/tests/fixtures/edge_list_invalid_directed.csv
@@ -1,0 +1,2 @@
+source,target,edge_id,directed
+n1,n2,e1,maybe

--- a/data_source_csv/tests/fixtures/edge_list_missing_columns.csv
+++ b/data_source_csv/tests/fixtures/edge_list_missing_columns.csv
@@ -1,0 +1,2 @@
+source,edge_id
+n1,e1

--- a/data_source_csv/tests/fixtures/edge_list_valid.csv
+++ b/data_source_csv/tests/fixtures/edge_list_valid.csv
@@ -1,0 +1,3 @@
+source,target,edge_id,directed,source_age,target_age,edge_weight,source_joined
+n1,n2,e1,true,21,22,0.5,2024-01-10
+n2,n3,e2,false,22,23,1.25,2024-02-11

--- a/data_source_csv/tests/test_csv_data_source_plugin.py
+++ b/data_source_csv/tests/test_csv_data_source_plugin.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from datetime import date
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+for package_dir in ("api", "platform", "data_source_csv"):
+    resolved = PROJECT_ROOT / package_dir
+    if str(resolved) not in sys.path:
+        sys.path.insert(0, str(resolved))
+
+from csv_data_source.errors import CsvParameterError, CsvParsingError
+from csv_data_source.models import CsvLoadConfig, CsvRows, ParsedEdge, ParsedGraphData
+from csv_data_source.pipeline import CsvParsingPipeline
+from csv_data_source.plugin import CsvDataSourcePlugin
+from graph_api.model.edge import Edge
+from graph_api.model.graph import Graph
+from graph_api.model.node import Node
+from graph_platform.core.plugin_registry import PluginRegistry
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+class TemplateMethodPipelineTests(unittest.TestCase):
+    class SpyPipeline(CsvParsingPipeline):
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def load(self, parameter_values: dict[str, str]) -> CsvLoadConfig:
+            self.calls.append("load")
+            return CsvLoadConfig(
+                file_path=Path("fake.csv"),
+                format_name="edge_list",
+                delimiter=",",
+                graph_id="spy",
+            )
+
+        def read(self, config: CsvLoadConfig) -> CsvRows:
+            self.calls.append("read")
+            return CsvRows(fieldnames=("source", "target"), rows=[{"source": "A", "target": "B"}])
+
+        def parse(self, csv_rows: CsvRows, config: CsvLoadConfig) -> ParsedGraphData:
+            self.calls.append("parse")
+            return ParsedGraphData(
+                node_attributes={"A": {}, "B": {}},
+                edges=[
+                    ParsedEdge(
+                        edge_id="e1",
+                        source_id="A",
+                        target_id="B",
+                        directed=True,
+                        attributes={},
+                    )
+                ],
+            )
+
+        def build(self, parsed_graph: ParsedGraphData, config: CsvLoadConfig) -> Graph:
+            self.calls.append("build")
+            graph = Graph(graph_id=config.graph_id, directed_default=True, allow_cycles=True)
+            graph.add_node(Node(node_id="A"))
+            graph.add_node(Node(node_id="B"))
+            graph.add_edge(Edge(edge_id="e1", source_id="A", target_id="B", directed=True))
+            return graph
+
+        def validate(self, graph: Graph, config: CsvLoadConfig) -> None:
+            self.calls.append("validate")
+
+    def test_template_method_executes_steps_in_order(self) -> None:
+        pipeline = self.SpyPipeline()
+        graph = pipeline.execute({})
+        self.assertEqual(graph.graph_id, "spy")
+        self.assertEqual(pipeline.calls, ["load", "read", "parse", "build", "validate"])
+
+
+class CsvDataSourcePluginTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.plugin = CsvDataSourcePlugin()
+
+    def _params(self, fixture_name: str, **overrides: str) -> dict[str, str]:
+        params = {
+            "file_path": str(FIXTURES_DIR / fixture_name),
+            "format": "edge_list",
+        }
+        params.update(overrides)
+        return params
+
+    def test_parameters_metadata_is_exposed(self) -> None:
+        parameter_names = {parameter.name for parameter in self.plugin.parameters}
+        self.assertEqual(parameter_names, {"file_path", "format", "delimiter", "graph_id"})
+
+    def test_edge_list_happy_path_builds_graph_with_inferred_types(self) -> None:
+        graph = self.plugin.load_graph(self._params("edge_list_valid.csv"))
+
+        self.assertEqual(graph.graph_id, "edge_list_valid")
+        self.assertEqual(set(graph.nodes.keys()), {"n1", "n2", "n3"})
+        self.assertEqual(set(graph.edges.keys()), {"e1", "e2"})
+
+        self.assertIsInstance(graph.nodes["n1"].attributes["age"], int)
+        self.assertEqual(graph.nodes["n1"].attributes["age"], 21)
+        self.assertIsInstance(graph.nodes["n1"].attributes["joined"], date)
+        self.assertIsInstance(graph.edges["e1"].attributes["weight"], float)
+        self.assertFalse(graph.edges["e2"].directed)
+
+    def test_missing_required_parameter_raises_error(self) -> None:
+        with self.assertRaises(CsvParameterError):
+            self.plugin.load_graph({"format": "edge_list"})
+
+    def test_unsupported_format_raises_error(self) -> None:
+        with self.assertRaises(CsvParameterError):
+            self.plugin.load_graph(
+                {
+                    "file_path": str(FIXTURES_DIR / "edge_list_valid.csv"),
+                    "format": "unknown_format",
+                }
+            )
+
+    def test_missing_required_columns_raises_error(self) -> None:
+        with self.assertRaises(CsvParsingError):
+            self.plugin.load_graph(self._params("edge_list_missing_columns.csv"))
+
+    def test_invalid_directed_value_raises_error(self) -> None:
+        with self.assertRaises(CsvParsingError):
+            self.plugin.load_graph(self._params("edge_list_invalid_directed.csv"))
+
+    def test_plugin_works_with_platform_registry(self) -> None:
+        registry = PluginRegistry()
+        registry.register_data_source(self.plugin)
+        loaded_plugin = registry.get_data_source(self.plugin.plugin_id)
+
+        graph = loaded_plugin.load_graph(self._params("edge_list_valid.csv"))
+        self.assertEqual(len(graph.nodes), 3)
+        self.assertEqual(len(graph.edges), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a new pluggable CSV data source plugin for the graph visualization platform, implementing the shared `DataSourcePlugin` contract and supporting CSV parsing via a template method pipeline with strategy-based format handling. The plugin currently supports the `edge_list` CSV format, provides robust parameter validation and type inference, and includes comprehensive tests and documentation.

**Core Plugin Implementation:**

* Added `CsvDataSourcePlugin` class, implementing the `DataSourcePlugin` contract, with parameter metadata, plugin registration, and a `load_graph` method that builds graphs from CSV files. (`csv_data_source/plugin.py`)
* Implemented a template method pipeline (`CsvParsingPipeline` and `DefaultCsvParsingPipeline`) for CSV parsing, including robust parameter validation, reading, parsing, building, and validating graphs. (`csv_data_source/pipeline.py`)
* Introduced a strategy pattern for CSV format parsing, with `EdgeListCsvStrategy` fully implemented and extension points for `adjacency_list` and `matrix` formats. (`csv_data_source/strategies.py`)

**Type Inference and Error Handling:**

* Added type inference for attribute values (int, float, date, str) and custom error classes for parameter and parsing errors. (`csv_data_source/type_inference.py`, `csv_data_source/errors.py`) [[1]](diffhunk://#diff-b974c92aef27bc53ee07557d3b6c1b026d0aa5dc0afb643d8b5d4d415c686c0dR1-R30) [[2]](diffhunk://#diff-278a253ceb0f952f04a7d6fc4673287bf4d6626e58ea84f2f4d133cdaa757bc9R1-R10)

**Documentation, Packaging, and Testing:**

* Provided a detailed README describing plugin usage, parameters, supported formats, and examples. (`README.md`)
* Added packaging configuration for plugin discovery and installation. (`pyproject.toml`)
* Included unit tests and CSV fixtures covering happy path, parameter validation, unsupported formats, missing columns, and invalid values. (`tests/test_csv_data_source_plugin.py`, `tests/fixtures/*.csv`) [[1]](diffhunk://#diff-e5195633cc70b1f04b4263095f14ff7f65b3dde8c057b7e5c0d60a4040d7878bR1-R138) [[2]](diffhunk://#diff-81fee3cc24d60d5a545fb71a332ae67fb812036790487d96b0665d8b3a239e8fR1-R3) [[3]](diffhunk://#diff-b51bfb6e64f004fe8566bbb5a40214a944a523edcf47c41840f569df35a6434eR1-R2) [[4]](diffhunk://#diff-c92846f0268b877413b37ee8791b1ba49874f23257682adfe9bb8f44d9fa754eR1-R2)